### PR TITLE
Update entrypoint.sh

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-/usr/bin/python3 "/lto-node/starter.py"
+python3 "/lto-node/starter.py"
 echo "Node is starting..."
 /usr/bin/java -Dlogback.stdout.level="${LTO_LOG_LEVEL}" "-Xmx${LTO_HEAP_SIZE}" -jar "/lto-node/lto-public-all.jar" $LTO_CONFIG_FILE


### PR DESCRIPTION
When using Red Hat Enterprise Linux 7 Universal Base Image a specification of the Python path is not required.