### PR TITLE
Add voting feature to lto-mainnet.conf

### DIFF
--- a/lto-mainnet.conf
+++ b/lto-mainnet.conf
@@ -25,6 +25,11 @@ lto {
     # declared-address = "1.2.3.4:6868"
   }
 
+  # Voting example
+  features {
+    supported = [ "4", "12" ]
+  }
+
   # Wallet settings
   wallet {
     # Password to protect wallet file


### PR DESCRIPTION
For those who run the lto-public-all-arm.jar directly with Java without Docker. This can be useful for different chip sets (non x86-64).